### PR TITLE
Fix project key formatting 

### DIFF
--- a/jiralib.py
+++ b/jiralib.py
@@ -134,7 +134,7 @@ class JiraProject:
             return self.j.issue(issue_key)
 
         issue_search = 'project={jira_project} and description ~ "{key}"'.format(
-            jira_project=self.projectkey,
+            jira_project='\"{}\"'.format(self.projectkey),
             key=STATE_ISSUE_KEY
         )
         issues = list(
@@ -223,7 +223,7 @@ class JiraProject:
         else:
             key = util.make_alert_key(repo_id, alert_num)
         issue_search = 'project={jira_project} and description ~ "{key}"'.format(
-            jira_project=self.projectkey,
+            jira_project='\"{}\"'.format(self.projectkey),
             key=key
         )
         issues = list(filter(lambda i: i.is_managed(), [JiraIssue(self, raw) for raw in self.j.search_issues(issue_search, maxResults=0)]))


### PR DESCRIPTION
If a user's Jira project is any of the reserved keywords, such as `IN`, `AND` or `OR`, JQL will fail with the following:

```
text: Error in JQL Query: Expecting either a value, list or function but got 'IN'. You must surround 'IN' in quotation marks to use it as a value. (line 1, character 9)
```
Going with this suggestion, literally surrounding the string with quotes and passing that to the project key flag doesn't currently work in this integration. Even escaping quotes doesn't work, although it would pass the JQL query. Also putting in the URL encoding of quotations or percent sign doesn't work:

```
No project could be found with key '"IN"'
```

Jira Support gave some pointers; as you can see the endpoints below, the following requests are valid and returns results (if any):
https://****.com/rest/api/2/search?jql=project=%22IN%22
https://****.com/rest/api/2/search?jql=project="IN"

So for all strings that we passed to the project key flag, format the string with quotes to avoid the JQL query error.

These are valid inputs for the flag when using the CLI (should work for Actions too):

With quotes
```
./gh2jira sync \
                 --gh-url https://api.github.com \
                 --gh-token some-token \
                 --gh-org some-org \
                 --gh-repo some-repo \
                 --jira-url some-jira-instance \
                 --jira-user some-user \
                 --jira-token some-token \
                 --jira-project "IN" \
                 --direction gh2jira
```

Without quotes
```
./gh2jira sync \
                 --gh-url https://api.github.com \
                 --gh-token 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 \
                 --gh-org advanced-security \
                 --gh-repo javascript-codeql-cli-test-workflow \
                 --jira-url https://jira.demo-stack.com \
                 --jira-user cmboling \
                 --jira-token ghas-user-testing \
                 --jira-project IN \
                 --direction gh2jira
```