### PR TITLE
Sync labels to Jira

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'JIRA project key'
     required: true
   jira_label:
-    description: 'JIRA bug label(s). Value format "red-team,blue-team,GreenTeam", or "red-team"
+    description: 'JIRA bug label(s). (e.g. value format can be "red-team,blue-team,GreenTeam", or "red-team")
                   This tool will split the values entered by commas. Spaces in the double quotes
                   will be respected and saved.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   jira_project:
     description: 'JIRA project key'
     required: true
-  jira_label:
-    description: 'JIRA bug label(s). (e.g. valid format can be "red-team,blue-team,GreenTeam", or "red-team")
+  jira_labels:
+    description: 'JIRA bug label(s). (e.g. valid format can be "red-team,blue-team,green-team", or "red-team")
                   This tool will split the values entered by commas. Spaces in the double quotes
                   will be respected and saved.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     description: 'JIRA project key'
     required: true
   jira_label:
-    description: 'JIRA bug label(s). (e.g. value format can be "red-team,blue-team,GreenTeam", or "red-team")
+    description: 'JIRA bug label(s). (e.g. valid format can be "red-team,blue-team,GreenTeam", or "red-team")
                   This tool will split the values entered by commas. Spaces in the double quotes
                   will be respected and saved.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,11 @@ inputs:
   jira_project:
     description: 'JIRA project key'
     required: true
+  jira_label:
+    description: 'JIRA bug label(s). Value format "red-team,blue-team,GreenTeam", or "red-team"
+                  This tool will split the values entered by commas. Spaces in the double quotes
+                  will be respected and saved.'
+    required: false
   github_token:
     description: 'GitHub API token with the required permissions'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Sync Code Scanning and JIRA'
-description: "Let's you manage Code Scanning alerts from JIRA by creating an
-              issue for each alert and keeping the states synced."
+name: 'Sync GitHub Advanced Security and Jira'
+description: "This helps sync GHAS alerts to JIRA by creating an
+              issue for each alert."
 inputs:
   jira_url:
     description: 'URL of the JIRA instance'

--- a/cli.py
+++ b/cli.py
@@ -54,7 +54,7 @@ def serve(args):
     s = Sync(
         github,
         jira.getProject(args.jira_project, args.jira_label),
-        direction=direction_str_to_num(args.direction)
+        direction=direction_str_to_num(args.direction),
     )
     server.run_server(s, args.secret, port=args.port)
 
@@ -81,7 +81,10 @@ def sync(args):
     github = ghlib.GitHub(args.gh_url, args.gh_token)
     jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
     jira_project = jira.getProject(
-        args.jira_project, args.issue_end_state, args.issue_reopen_state, args.jira_label
+        args.jira_project,
+        args.issue_end_state,
+        args.issue_reopen_state,
+        args.jira_label,
     )
     repo_id = args.gh_org + "/" + args.gh_repo
 
@@ -197,14 +200,11 @@ def main():
         default=os.getenv("GH2JIRA_JIRA_TOKEN"),
     )
     credential_base.add_argument("--jira-project", help="JIRA project key")
+    credential_base.add_argument("--jira-label", help="JIRA bug label(s)")
     credential_base.add_argument(
-        '--jira-label',
-        help='JIRA bug label(s)'
-    )
-    credential_base.add_argument(
-        '--secret',
-        help='Webhook secret. Alternatively, the GH2JIRA_SECRET may be set.',
-        default=os.getenv('GH2JIRA_SECRET')
+        "--secret",
+        help="Webhook secret. Alternatively, the GH2JIRA_SECRET may be set.",
+        default=os.getenv("GH2JIRA_SECRET"),
     )
 
     direction_base = argparse.ArgumentParser(add_help=False)

--- a/cli.py
+++ b/cli.py
@@ -50,10 +50,10 @@ def serve(args):
         fail('No Webhook secret specified!')
 
     github = ghlib.GitHub(args.gh_url, args.gh_token)
-    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token, args.jira_label)
+    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
     s = Sync(
         github,
-        jira.getProject(args.jira_project),
+        jira.getProject(args.jira_project, args.jira_label),
         direction=direction_str_to_num(args.direction)
     )
     server.run_server(s, args.secret, port=args.port)

--- a/cli.py
+++ b/cli.py
@@ -50,7 +50,7 @@ def serve(args):
         fail('No Webhook secret specified!')
 
     github = ghlib.GitHub(args.gh_url, args.gh_token)
-    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
+    jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token, args.jira_label)
     s = Sync(
         github,
         jira.getProject(args.jira_project),
@@ -80,7 +80,7 @@ def sync(args):
 
     github = ghlib.GitHub(args.gh_url, args.gh_token)
     jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
-    jira_project = jira.getProject(args.jira_project)
+    jira_project = jira.getProject(args.jira_project, args.jira_label)
     repo_id = args.gh_org + '/' + args.gh_repo
 
     if args.state_file:
@@ -211,6 +211,10 @@ def main():
     credential_base.add_argument(
         '--jira-project',
         help='JIRA project key'
+    )
+    credential_base.add_argument(
+        '--jira-label',
+        help='JIRA bug label(s)'
     )
     credential_base.add_argument(
         '--secret',

--- a/cli.py
+++ b/cli.py
@@ -53,7 +53,7 @@ def serve(args):
     jira = jiralib.Jira(args.jira_url, args.jira_user, args.jira_token)
     s = Sync(
         github,
-        jira.getProject(args.jira_project, args.jira_label),
+        jira.getProject(args.jira_project, args.jira_labels),
         direction=direction_str_to_num(args.direction),
     )
     server.run_server(s, args.secret, port=args.port)
@@ -84,7 +84,7 @@ def sync(args):
         args.jira_project,
         args.issue_end_state,
         args.issue_reopen_state,
-        args.jira_label,
+        args.jira_labels,
     )
     repo_id = args.gh_org + "/" + args.gh_repo
 
@@ -200,7 +200,7 @@ def main():
         default=os.getenv("GH2JIRA_JIRA_TOKEN"),
     )
     credential_base.add_argument("--jira-project", help="JIRA project key")
-    credential_base.add_argument("--jira-label", help="JIRA bug label(s)")
+    credential_base.add_argument("--jira-labels", help="JIRA bug label(s)")
     credential_base.add_argument(
         "--secret",
         help="Webhook secret. Alternatively, the GH2JIRA_SECRET may be set.",

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,5 +9,6 @@ cd / && pipenv run /gh2jira sync \
                             --jira-user "$INPUT_JIRA_USER" \
                             --jira-token "$INPUT_JIRA_TOKEN" \
                             --jira-project "$INPUT_JIRA_PROJECT" \
+                            --jira-label "$INPUT_JIRA_LABEL" \
                             --direction "$INPUT_SYNC_DIRECTION" \
                             --state-issue -

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ cd / && pipenv run /gh2jira sync \
                             --jira-user "$INPUT_JIRA_USER" \
                             --jira-token "$INPUT_JIRA_TOKEN" \
                             --jira-project "$INPUT_JIRA_PROJECT" \
-                            --jira-label "$INPUT_JIRA_LABEL" \
+                            --jira-labels "$INPUT_JIRA_LABELS" \
                             --direction "$INPUT_SYNC_DIRECTION" \
                             --issue-end-state "$INPUT_ISSUE_END_STATE" \
                             --issue-reopen-state "$INPUT_ISSUE_REOPEN_STATE" \

--- a/jiralib.py
+++ b/jiralib.py
@@ -50,13 +50,12 @@ class Jira:
         self.token = token
         self.j = JIRA(url, basic_auth=(user, token))
 
-
     def auth(self):
         return self.user, self.token
 
 
-    def getProject(self, projectkey):
-        return JiraProject(self, projectkey)
+    def getProject(self, projectkey, label):
+        return JiraProject(self, projectkey, label)
 
 
     def list_hooks(self):
@@ -123,8 +122,12 @@ class Jira:
 
 
 class JiraProject:
-    def __init__(self, jira, projectkey):
+    def __init__(self, jira, projectkey, label):
         self.jira = jira
+        if label:
+            self.label = label.split(',')
+        if not label:
+            self.label = []
         self.projectkey = projectkey
         self.j = self.jira.j
 
@@ -206,7 +209,8 @@ class JiraProject:
                 repo_key=util.make_key(repo_id),
                 alert_key=util.make_alert_key(repo_id, alert_num)
             ),
-            issuetype={'name': 'Bug'}
+            issuetype={'name': 'Bug'},
+            labels=self.label
         )
         logger.info('Created issue {issue_key} for alert {alert_num} in {repo_id}.'.format(
             issue_key=raw.key,

--- a/jiralib.py
+++ b/jiralib.py
@@ -99,7 +99,7 @@ class JiraProject:
     def __init__(self, jira, projectkey, endstate, reopenstate, label):
         self.jira = jira
         if label:
-            self.label = label.split(',')
+            self.label = label.split(",")
         if not label:
             self.label = []
         self.projectkey = projectkey
@@ -172,7 +172,7 @@ class JiraProject:
                 alert_key=util.make_alert_key(repo_id, alert_num),
             ),
             issuetype={"name": "Bug"},
-            labels=self.label
+            labels=self.label,
         )
         logger.info(
             "Created issue {issue_key} for alert {alert_num} in {repo_id}.".format(

--- a/sync.py
+++ b/sync.py
@@ -14,6 +14,7 @@ class Sync:
         self.github = github
         self.jira = jira_project
         self.direction = direction
+        self.labels = self.jira.labels
 
     def alert_created(self, repo_id, alert_num):
         self.sync(
@@ -103,10 +104,12 @@ class Sync:
             # we have to push back the state to JIRA, because "fixed"
             # alerts cannot be transitioned to "open"
             issue.adjust_state(alert.get_state())
+            issue.persist_labels(self.labels)
             return alert.get_state()
         else:
             # The user treats JIRA as the source of truth
             alert.adjust_state(issue.get_state())
+            issue.persist_labels(self.labels)
             return issue.get_state()
 
     def sync_repo(self, repo_id, states=None):


### PR DESCRIPTION
Adds the functionality to be able to add labels to newly created Jira bugs. 

A user can add
```
with:
    jira_label: 'red-team,GreenTeam,blueteam'
```
to their GitHub -> Jira workflows to have those labels added to the Jira bugs.